### PR TITLE
Refactoring and simplifications (and improvements)

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -50,13 +50,13 @@ async def quote_loop():
             await send_quote()
 
 @client.event
-async def send_quote(pre: str="Quote"):
+async def send_quote(pre = "Quote"):
     quotes = await refresh_quotes() # This way we have access to the latest quotes
     logger = logging.getLogger("send_quote")
-    quote = pull_random_quote(quotes)
-    embedVar = discord.Embed(title = "Maximum Swack!", description = quote[1], colour = random.choice(colours))
-    embedVar.set_footer(text = f"{pre} for {datetime.now().strftime('%A %-d %B %Y')}\nSubmitted by {quote[0]}")
-    logger.info(f"Sending quote: {quote}")
+    submitter, quote = pull_random_quote(quotes)
+    embedVar = discord.Embed(title = "Maximum Swack!", description = quote, colour = random.choice(colours))
+    embedVar.set_footer(text = f"{pre} for {datetime.now().strftime('%A %-d %B %Y')}\nSubmitted by {submitter}")
+    logger.info(f"Sending quote from {submitter}: {quote}")
     await client.get_channel(sandbox).send(embed = embedVar)
 
 # Run the thing

--- a/bot.py
+++ b/bot.py
@@ -46,12 +46,12 @@ async def quote_loop():
         await asyncio.sleep(MINUTE)
         now = datetime.now()
         if previous.hour != now.now().hour and now.hour == 12:
-            await refresh_quotes()
             await asyncio.sleep(15)
             await send_quote()
 
 @client.event
 async def send_quote(pre: str="Quote"):
+    quotes = await refresh_quotes() # This way we have access to the latest quotes
     logger = logging.getLogger("send_quote")
     quote = pull_random_quote(quotes)
     embedVar = discord.Embed(title = "Maximum Swack!", description = quote[1], colour = random.choice(colours))

--- a/bot.py
+++ b/bot.py
@@ -53,7 +53,7 @@ async def quote_loop():
 @client.event
 async def send_quote(pre: str="Quote"):
     logger = logging.getLogger("send_quote")
-    quote = quotes[pull_random_quote()]
+    quote = pull_random_quote(quotes)
     embedVar = discord.Embed(title = "Maximum Swack!", description = quote[1], colour = random.choice(colours))
     embedVar.set_footer(text = f"{pre} for {datetime.now().strftime('%A %-d %B %Y')}\nSubmitted by {quote[0]}")
     logger.info(f"Sending quote: {quote}")

--- a/quotes.py
+++ b/quotes.py
@@ -5,34 +5,54 @@ import asyncio
 
 QUOTE_FILE_ADDRESS = 'https://raw.githubusercontent.com/Gnomeball/QuoteBotRepo/main/quotes.txt'
 
-def pull_random_quote():
-    with open("quotes.txt", "r") as f:
-        all_q = set(range(1, len(f.read().splitlines()) +1))
+def pull_random_quote(quotes):
+    """
+    Selects a random quote from the given list.
+    Currently, ignores the last 100 quotes that appear in "quote_history.txt".
+    :returns: A (submitter, quote) pair.
+    :rtype: Tuple[str,str]
+    """
+    all_q = set(range(1, len(quotes)+1)) # This way the index stuff is entirely internal.
 
     with open("quote_history.txt", "r") as f:
         good_q = sorted(all_q - set(map(int, f.read().splitlines()[-100:])))
 
-    random.shuffle(good_q)
-    shortlist = random.sample(good_q, 50)
-
-    random.shuffle(shortlist)
-    quote = random.choice(shortlist)
+    random.shuffle(good_q) # shortlisting has no effect since we always pick one successfully
+    quote = random.choice(good_q)
 
     with open("quote_history.txt", "a") as f:
         f.write(f"{quote}\n")
 
-    return quote
+    return quotes[quote]
 
+def parse_quotes(lst):
+    """
+    Parse (submitter, quote) pairs from a given list of strings.
+    The format is currently `submitter###quote`.
+    TODO: Multiline quote support.
+    :returns: A list of parsed (submitter, quote) pairs.
+    :rtype: List[Tuple[str,str]]
+    """
+    return [tuple(quote.split("###", maxsplit = 1)) for quote in lst]
+
+def pull_quotes_from_file(path="quotes.txt"):
+    """
+    Pulls the quotes from a local file (default: "quotes.txt").
+    :returns: The list of (submitter, quote) pairs from the file.
+    :rtype: List[Tuple[str,str]]
+    """
+    with open(path, "r") as f:
+        return parse_quotes(f.read().splitlines())
 
 def pull_quotes_from_repo():
     """
     Pulls updated quotes from the repository.
-    :returns: An updated quotes.txt as a list of strings.
-              On error, returns an empty string and logs exception.
-    :rtype: List[List[str]]
+    :returns: Updated quotes as a list of (submitter, quote) pairs.
+              On error, returns an empty list and logs exception.
+    :rtype: List[Tuple[str,str]]
     """
     logger = logging.getLogger("pull_from_repo")
-    updated_quotes: str = ''
+    updated_quotes = ""
     try:
         logger.info(f"Updating quotes from: {QUOTE_FILE_ADDRESS}")
         req = requests.get(QUOTE_FILE_ADDRESS)
@@ -42,39 +62,31 @@ def pull_quotes_from_repo():
         else: updated_quotes = req.text
     except Exception:
         logger.exception("Exception while getting updated quotes:")
-    return [quote.split("###", maxsplit = 1) for quote in updated_quotes.splitlines()]
-
-
-def pull_quotes_from_file():
-    quotes = []
-    with open("quotes.txt", "r") as file:
-        quotes = [quote.split("###", maxsplit = 1) for quote in file.read().splitlines()]
-    return quotes
-
+    return parse_quotes(updated_quotes.splitlines())
 
 async def refresh_quotes():
     """
     Overwrites quotes.txt with potentially updated ones.
+    If we cannot reach the repo, we always fallback to local.
     Probably don't call this one from two different threads.
-    :param quotes: Reference to an existing list of quotes
-    :type updated_quotes: List[List[str]]
-    :returns: None
+    :returns: The most up-to-date set of quotes we can access.
+    :rtype: List[Tuple[str,str]]
     """
     logger = logging.getLogger("refresh_quotes")
     quotes = pull_quotes_from_file()
     updated_quotes = pull_quotes_from_repo()
-    if not updated_quotes:
-        return
+    if updated_quotes == []:
+        return quotes
     # calc & pretty-print diff to log in a horrible way; cpu go brrr
     additions = [q for q in updated_quotes if q not in quotes]
     removals  = [q for q in quotes if q not in updated_quotes]
-    for a in additions:
-        logger.info(f"+ {' '.join(a)}")
-    for r in removals:
-        logger.info(f"- {' '.join(r)}")
+    for submitter,quote in additions:
+        logger.info(f"+ {submitter} {quote}")
+    for submitter,quote in removals:
+        logger.info(f"- {submitter} {quote}")
 
     if quotes != updated_quotes:
-        flattened_quotes = '\n'.join([f'{author}###{quote}' for author,quote in updated_quotes])
+        flattened_quotes = "\n".join([f"{submitter}###{quote}" for submitter,quote in updated_quotes])
         with open("quotes.txt", "w") as f:
             f.write(flattened_quotes)
     return updated_quotes


### PR DESCRIPTION
Right, this is a pretty big one, certainly relative to the others I've submitted.

The most important change: we have a `parse_quotes` function! I've thus reified the type and tried to make everything consistent to this, we already had code relying on the list containing `(submitter, quote)` pairs, so I've made it canon. 

All code that was doing this parsing now uses the function, with any changes made to accomodate (such as in comments).

A couple things here and there: stuff that said it did one thing and then did another, I've tried to make either do one (`pull_quotes_from_repo`) or both (`refresh_quotes`). Everything should be more consistent to how the code is actually used, which in the case of `refresh_quotes` meant changing the callsite to within `send_quote`, as we presumably want to actually use the updated quotes.

Currently, the "quote index" situation is partially resolved, and is now entirely internal to `pull_random_quote`. This might be acceptable, since we can improve parsing to handle multi-lines later and this should not break. Unfortunately, the way `refresh_quotes` prepares `flattened_quotes` is fragile, since it relies on current parsing behaviour (it was also the code that already presumed `(submitter, quote)` pairs). If anyone adds multiline support, or a bot command to add a new quote, then it's probably worth refactoring this into a standalone stringifier alongside the parsing... we'll build that bridge when we get to it, however.

And a final thing: shortlisting when you are pulling only a single quote only matters when you may need to fallback, which we don't. So I guess that's the real simplification 👍 